### PR TITLE
ref: add domain argument to user & verifier data functions

### DIFF
--- a/src/IStarknetID.cairo
+++ b/src/IStarknetID.cairo
@@ -28,24 +28,24 @@ namespace IStarknetid {
     func tokenURI(tokenId: Uint256) -> (tokenURI_len: felt, tokenURI: felt*) {
     }
 
-    func get_user_data(starknet_id: felt, field: felt) -> (data: felt) {
+    func get_user_data(starknet_id: felt, field: felt, domain: felt) -> (data: felt) {
     }
 
-    func get_extended_user_data(starknet_id: felt, field: felt, length: felt) {
+    func get_extended_user_data(starknet_id: felt, field: felt, length: felt, domain: felt) {
     }
 
-    func get_unbounded_user_data(starknet_id: felt, field: felt) -> (data_len: felt, data: felt*) {
+    func get_unbounded_user_data(starknet_id: felt, field: felt, domain: felt) -> (data_len: felt, data: felt*) {
     }
 
-    func get_verifier_data(starknet_id: felt, field: felt, address: felt) -> (data: felt) {
+    func get_verifier_data(starknet_id: felt, field: felt, address: felt, domain: felt) -> (data: felt) {
     }
 
     func get_extended_verifier_data(
-        starknet_id: felt, field: felt, length: felt, address: felt
+        starknet_id: felt, field: felt, length: felt, address: felt, domain: felt
     ) -> (data_len: felt, data: felt*) {
     }
 
-    func get_unbounded_verifier_data(starknet_id: felt, field: felt, address: felt) -> (
+    func get_unbounded_verifier_data(starknet_id: felt, field: felt, address: felt, domain: felt) -> (
         data_len: felt, data: felt*
     ) {
     }
@@ -70,16 +70,16 @@ namespace IStarknetid {
     func mint(starknet_id: felt) {
     }
 
-    func set_user_data(starknet_id: felt, field: felt, data: felt) {
+    func set_user_data(starknet_id: felt, field: felt, data: felt, domain: felt) {
     }
 
-    func set_extended_user_data(starknet_id: felt, field: felt, data_len: felt, data: felt*) {
+    func set_extended_user_data(starknet_id: felt, field: felt, data_len: felt, data: felt*, domain: felt) {
     }
 
-    func set_verifier_data(starknet_id: felt, field: felt, data: felt) {
+    func set_verifier_data(starknet_id: felt, field: felt, data: felt, domain: felt) {
     }
 
-    func set_extended_verifier_data(starknet_id: felt, field: felt, data_len: felt, data: felt*) {
+    func set_extended_verifier_data(starknet_id: felt, field: felt, data_len: felt, data: felt*, domain: felt) {
     }
 
     func equip(inft_contract: felt, inft_id: felt) {

--- a/src/StarknetId.cairo
+++ b/src/StarknetId.cairo
@@ -152,7 +152,7 @@ func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 //
 @view
 func get_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt
+    starknet_id: felt, field: felt, domain: felt,
 ) -> (data: felt) {
     let (data: felt) = user_data.read(starknet_id, field);
     return (data,);
@@ -160,7 +160,7 @@ func get_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
 
 @view
 func get_extended_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt, length: felt
+    starknet_id: felt, field: felt, length: felt, domain: felt,
 ) -> (data_len: felt, data: felt*) {
     let (addr: felt) = user_data.addr(starknet_id, field);
     return read_extended_data(addr, length);
@@ -168,7 +168,7 @@ func get_extended_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
 
 @view
 func get_unbounded_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt
+    starknet_id: felt, field: felt, domain: felt,
 ) -> (data_len: felt, data: felt*) {
     alloc_locals;
     let (arr) = alloc();
@@ -179,7 +179,7 @@ func get_unbounded_user_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ran
 
 @view
 func get_verifier_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt, address: felt
+    starknet_id: felt, field: felt, address: felt, domain: felt,
 ) -> (data: felt) {
     let (data: felt) = verifier_data.read(starknet_id, field, address);
     return (data,);
@@ -187,7 +187,7 @@ func get_verifier_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 
 @view
 func get_extended_verifier_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt, length: felt, address: felt
+    starknet_id: felt, field: felt, length: felt, address: felt, domain: felt,
 ) -> (data_len: felt, data: felt*) {
     let (addr: felt) = verifier_data.addr(starknet_id, field, address);
     return read_extended_data(addr, length);
@@ -195,7 +195,7 @@ func get_extended_verifier_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, 
 
 @view
 func get_unbounded_verifier_data{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    starknet_id: felt, field: felt, address: felt
+    starknet_id: felt, field: felt, address: felt, domain: felt,
 ) -> (data_len: felt, data: felt*) {
     alloc_locals;
     let (arr) = alloc();
@@ -269,7 +269,7 @@ func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(stark
 //
 @external
 func set_user_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    starknet_id: felt, field: felt, data: felt
+    starknet_id: felt, field: felt, data: felt, domain: felt,
 ) {
     let (owner) = ERC721.owner_of(Uint256(starknet_id, 0));
     let (caller) = get_caller_address();
@@ -282,7 +282,7 @@ func set_user_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_p
 // note: when working with multiple sizes, make sure to write data_len+1 with last_value = 0
 @external
 func set_extended_user_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    starknet_id: felt, field: felt, data_len: felt, data: felt*
+    starknet_id: felt, field: felt, data_len: felt, data: felt*, domain: felt,
 ) {
     alloc_locals;
     let (owner) = ERC721.owner_of(Uint256(starknet_id, 0));
@@ -296,7 +296,7 @@ func set_extended_user_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, rang
 
 @external
 func set_verifier_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    starknet_id: felt, field: felt, data: felt
+    starknet_id: felt, field: felt, data: felt, domain: felt,
 ) {
     let (address) = get_caller_address();
     VerifierDataUpdate.emit(starknet_id, field, data, address);
@@ -307,7 +307,7 @@ func set_verifier_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_che
 // note: when working with multiple sizes, make sure to write data_len+1 with last_value = 0
 @external
 func set_extended_verifier_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    starknet_id: felt, field: felt, data_len: felt, data: felt*
+    starknet_id: felt, field: felt, data_len: felt, data: felt*, domain: felt,
 ) {
     alloc_locals;
     let (author) = get_caller_address();

--- a/tests/test_extended_data.cairo
+++ b/tests/test_extended_data.cairo
@@ -23,32 +23,32 @@ func test_verifier_extended_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*,
     let token_id = 1;
     mint(token_id);
     // should set the avatar of specified token_id to [ 12345, 6789 ]
-    set_extended_verifier_data(token_id, 'avatar', 2, new (12345, 6789));
+    set_extended_verifier_data(token_id, 'avatar', 2, new (12345, 6789), 0);
     // should retrieve it by specifying the array length
-    let (len, values) = get_extended_verifier_data(token_id, 'avatar', 2, 123);
+    let (len, values) = get_extended_verifier_data(token_id, 'avatar', 2, 123, 0);
     assert len = 2;
     assert 12345 = values[0];
     assert 6789 = values[1];
 
     // should retrieve it without specifying the length (stops at 0)
-    let (len, values) = get_unbounded_verifier_data(token_id, 'avatar', 123);
+    let (len, values) = get_unbounded_verifier_data(token_id, 'avatar', 123, 0);
     assert len = 2;
     assert 12345 = values[0];
     assert 6789 = values[1];
 
     // should retrieve nothing
-    let (len, values) = get_unbounded_verifier_data(token_id, 'yolo', 123);
+    let (len, values) = get_unbounded_verifier_data(token_id, 'yolo', 123, 0);
     assert len = 0;
 
     // should retrieve an array of specified size full of 0
-    let (len, values) = get_extended_verifier_data(token_id, 'yolo', 3, 123);
+    let (len, values) = get_extended_verifier_data(token_id, 'yolo', 3, 123, 0);
     assert len = 3;
     assert values[0] = 0;
     assert values[1] = 0;
     assert values[2] = 0;
 
     // should not return any user data
-    let (len, values) = get_unbounded_user_data(token_id, 'avatar');
+    let (len, values) = get_unbounded_user_data(token_id, 'avatar', 0);
     assert len = 0;
 
     %{ stop_prank_callable() %}
@@ -63,32 +63,32 @@ func test_user_extended_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, ran
     let token_id = 1;
     mint(token_id);
     // should set the avatar of specified token_id to [ 12345, 6789 ]
-    set_extended_user_data(token_id, 'avatar', 2, new (12345, 6789));
+    set_extended_user_data(token_id, 'avatar', 2, new (12345, 6789), 0);
     // should retrieve it by specifying the array length
-    let (len, values) = get_extended_user_data(token_id, 'avatar', 2);
+    let (len, values) = get_extended_user_data(token_id, 'avatar', 2, 0);
     assert len = 2;
     assert 12345 = values[0];
     assert 6789 = values[1];
 
     // should retrieve it without specifying the length (stops at 0)
-    let (len, values) = get_unbounded_user_data(token_id, 'avatar');
+    let (len, values) = get_unbounded_user_data(token_id, 'avatar', 0);
     assert len = 2;
     assert 12345 = values[0];
     assert 6789 = values[1];
 
     // should retrieve nothing
-    let (len, values) = get_unbounded_user_data(token_id, 'yolo');
+    let (len, values) = get_unbounded_user_data(token_id, 'yolo', 0);
     assert len = 0;
 
     // should retrieve an array of specified size full of 0
-    let (len, values) = get_extended_user_data(token_id, 'yolo', 3);
+    let (len, values) = get_extended_user_data(token_id, 'yolo', 3, 0);
     assert len = 3;
     assert values[0] = 0;
     assert values[1] = 0;
     assert values[2] = 0;
 
     // should not return any verifier data
-    let (len, values) = get_unbounded_verifier_data(token_id, 'avatar', 123);
+    let (len, values) = get_unbounded_verifier_data(token_id, 'avatar', 123, 0);
     assert len = 0;
 
     %{ stop_prank_callable() %}

--- a/tests/test_starknetId.cairo
+++ b/tests/test_starknetId.cairo
@@ -27,7 +27,7 @@ func test_set_verifier_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, rang
     let type = 19256242726728292;  // # Discord
     let data = 58596348113441803209962597;  // # 0xBenaparte
 
-    set_verifier_data(token_id, type, data);
+    set_verifier_data(token_id, type, data, 0);
 
     // # valid case
     let (isValidData) = verifier_data.read(token_id, type, 123);
@@ -71,7 +71,7 @@ func test_set_user_data{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_ch
     let type = 19256242726728292;  // # Discord
     let data = 58596348113441803209962597;  // # 0xBenaparte
 
-    set_user_data(token_id, type, data);
+    set_user_data(token_id, type, data, 0);
 
     // valid case
     let (identityData) = user_data.read(token_id, type);


### PR DESCRIPTION
This PR adds a `domain` argument to all `user` data & `verifier` data functions. It's not used at the moment but we need to add it to match the implementation of the identity contract in cairo2. 